### PR TITLE
Not only slice valid params, permit them

### DIFF
--- a/lib/hal_api/controller/actions.rb
+++ b/lib/hal_api/controller/actions.rb
@@ -55,7 +55,7 @@ module HalApi::Controller::Actions
   end
 
   def valid_params_for_action(action)
-    (params.slice(*self.class.valid_params_list(action)) || {}).tap do |p|
+    (params.permit(*self.class.valid_params_list(action)) || {}).tap do |p|
       p[:zoom] = zoom_param if zoom_param
     end
   end


### PR DESCRIPTION
fixes `ArgumentError (render parameters are not permitted)` from using Rails 4.2.5.1 with security fixes for show actions