### PR TITLE
Fix profile urls

### DIFF
--- a/lib/hal_api/rails/version.rb
+++ b/lib/hal_api/rails/version.rb
@@ -1,5 +1,5 @@
 module HalApi
   module Rails
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/lib/hal_api/representer/uri_methods.rb
+++ b/lib/hal_api/representer/uri_methods.rb
@@ -78,10 +78,10 @@ module HalApi::Representer::UriMethods
       part.to_s.dasherize
     else
       klass = part.is_a?(Class) ? part : (part.try(:item_class) || part.class)
-      if klass.respond_to?(:base_class) && (klass.superclass != ActiveRecord::Base) && !klass.superclass.abstract_class
-        base = klass.superclass.name.underscore.dasherize
-        child = klass.name.underscore.gsub(/_#{base}$/, "").dasherize
-        [base, child]
+      if klass.respond_to?(:base_class) && !klass.superclass.name.demodulize.starts_with?('Base')
+        parent = klass.superclass.name.underscore.dasherize
+        child = klass.name.underscore.gsub(/_#{parent}$/, "").dasherize
+        [parent, child]
       else
         klass.name.underscore.dasherize
       end

--- a/test/hal_api/concerns/uri_methods_test.rb
+++ b/test/hal_api/concerns/uri_methods_test.rb
@@ -10,6 +10,19 @@ class TestUriMethods
   include HalApi::Representer::UriMethods
 end
 
+class BaseModelTest
+  def self.base_class; Class; end
+end
+
+class Widget < BaseModelTest
+end
+
+class VerySpecialThing < Widget
+end
+
+class SpecialWidget < Widget
+end
+
 describe HalApi::Representer::UriMethods do
 
   let(:helper) { TestUriMethods.new }
@@ -45,6 +58,11 @@ describe HalApi::Representer::UriMethods do
     helper.model_uri(:test_object).must_equal uri
     helper.model_uri(TestObject).must_equal uri
     helper.model_uri(t_object).must_equal uri
+
+    b = "http://meta.test.dev/model"
+    helper.model_uri(Widget.new).must_equal "#{b}/widget"
+    helper.model_uri(SpecialWidget.new).must_equal "#{b}/widget/special"
+    helper.model_uri(VerySpecialThing.new).must_equal "#{b}/widget/very-special-thing"
   end
 
   it 'returns the meta host' do

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -25,22 +25,6 @@ TestObject = Struct.new(:title, :is_root_resource) do
   end
 end
 
-TestParent = Struct.new(:id, :is_root_resource) do
-  extend ActiveModel::Naming
-
-  def persisted?
-    false
-  end
-
-  def to_model
-    self
-  end
-
-  def to_param
-    "#{id}"
-  end
-end
-
 module Api
 
   class BaseRepresenter < HalApi::Representer


### PR DESCRIPTION
If all models extend from a common app base class, but could also have a parent abstract class

```
class BaseModel < ActiveRecord::Base
  self.abstact_class = true
end

class Image < BaseModel
  self.abstact_class = true
end

class StoryImage < Image
end

class Story < BaseModel
end

```
The profile path for:
* Story should not include the `base-model` parent, should be `/model/story`
* StoryImage should include its parent as `model/image/story`
