### PR TITLE
Fix POST error rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /spec/reports/
 /tmp/
 .DS_Store
+/bundle/
+/log/

--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rails", "~> 4.2.1"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "kaminari"
 end

--- a/lib/hal_api/controller/exceptions.rb
+++ b/lib/hal_api/controller/exceptions.rb
@@ -8,10 +8,18 @@ module HalApi::Controller::Exceptions
     wrapper = ::ActionDispatch::ExceptionWrapper.new(env, exception)
     log_error(env, wrapper)
 
-    error = exception.is_a?(HalApi::Errors::ApiError) ? exception : HalApi::Errors::ApiError.new
+    error = if exception.is_a?(HalApi::Errors::ApiError)
+              exception
+            else
+              e = HalApi::Errors::ApiError.new(exception.message)
+              e.set_backtrace(exception.backtrace)
+              e
+            end
+
     respond_with(
       error,
       status: error.status,
+      location: nil, # for POST requests
       represent_with: HalApi::Errors::Representer
     )
   end

--- a/lib/hal_api/errors.rb
+++ b/lib/hal_api/errors.rb
@@ -28,5 +28,6 @@ module HalApi::Errors
 
     property :status
     property :message
+    property :backtrace, if: -> (*) { Rails.configuration.try(:consider_all_requests_local) }
   end
 end

--- a/test/hal_api/controller/exceptions_test.rb
+++ b/test/hal_api/controller/exceptions_test.rb
@@ -1,27 +1,57 @@
 require 'test_helper'
 
-describe HalApi::Errors do
-  describe HalApi::Errors::UnsupportedMediaType do
-    let(:subject) { HalApi::Errors::UnsupportedMediaType.new('foo') }
+describe HalApi::Controller::Exceptions < ActionController::TestCase do
+  include ActiveSupport::Testing::SetupAndTeardown
+  include ActionController::TestCase::Behavior
 
-    it 'has status 415' do
-      subject.status.must_equal 415
-    end
+  class TestRoutes
+    def extra_keys(*any) []; end
+    def path_for(*any) ''; end
+  end
 
-    it 'has a helpful message' do
-      subject.message.must_be :kind_of?, String
+  class ExceptionsTestController < ActionController::Base
+    include Roar::Rails::ControllerAdditions
+    include HalApi::Controller::Exceptions
+
+    respond_to :hal
+    rescue_from StandardError do |error| respond_with_error(error); end
+
+    def throwerror
+      raise StandardError.new('what now')
     end
   end
 
-  describe HalApi::Errors::NotFound do
-    let(:subject) { HalApi::Errors::NotFound.new }
+  before do
+    Rails.configuration.consider_all_requests_local = false
+    @controller = ExceptionsTestController.new
+    @request = ActionController::TestRequest.new
+    @response = ActionController::TestResponse.new
+    @routes = TestRoutes.new
+  end
 
-    it 'has status 404' do
-      subject.status.must_equal 404
-    end
+  it 'rescues from standard errors' do
+    get :throwerror, {format: :hal}
+    response.status.must_equal 500
+    json = JSON.parse(response.body)
+    json['status'].must_equal 500
+    json['message'].must_equal 'what now'
+    json.key?('backtrace').must_equal false
+  end
 
-    it 'has a helpful message' do
-      subject.message.must_be :kind_of?, String
-    end
+  it 'optionally shows backtraces' do
+    Rails.configuration.consider_all_requests_local = true
+    get :throwerror, {format: :hal}
+    json = JSON.parse(response.body)
+    json.key?('backtrace').must_equal true
+    json['backtrace'].must_be_instance_of Array
+  end
+
+  it 'does not try to set a location header for post errors' do
+    post :throwerror, {format: :hal}
+    response.status.must_equal 500
+    json = JSON.parse(response.body)
+    json['status'].must_equal 500
+    json['message'].must_equal 'what now'
+    response.headers['Location'].must_be_nil
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require "action_controller/railtie"
-# require "action_controller/test_case"
 require "action_view/railtie"
 require 'active_support/all'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require "action_controller/railtie"
+# require "action_controller/test_case"
 require "action_view/railtie"
 require 'active_support/all'
 
@@ -7,5 +8,21 @@ require 'responders'
 require 'roar-rails'
 require 'hal_api/rails'
 
+require 'pry-byebug'
 require 'minitest/spec'
 require 'minitest/autorun'
+
+ENV['RAILS_ENV'] = 'test'
+
+module Dummy
+  class Application < Rails::Application
+    config.encoding = 'utf-8'
+    config.eager_load = false
+    config.active_support.test_order = :random
+    config.secret_token = '1234'
+    config.secret_key_base = '5678'
+  end
+end
+Dummy::Application.initialize!
+
+require 'rails/test_help'


### PR DESCRIPTION
- Don't attempt to set a `Location` header on `POST` requests (resulting in an error that masks the first error)
- Render backtraces
- Set rendered message/backtrace from the original `StandardError`