### PR TITLE
Authorize and class attributes

### DIFF
--- a/lib/hal_api/controller.rb
+++ b/lib/hal_api/controller.rb
@@ -24,13 +24,6 @@ module HalApi::Controller
     hal_rescue_standard_errors
   end
 
-  module ClassMethods
-    include HalApi::Controller::Actions::ClassMethods
-    include HalApi::Controller::Cache::ClassMethods
-    include HalApi::Controller::Resources::ClassMethods
-    include HalApi::Controller::Exceptions::ClassMethods
-  end
-
   private
 
   def set_accepts

--- a/lib/hal_api/controller/actions.rb
+++ b/lib/hal_api/controller/actions.rb
@@ -1,4 +1,12 @@
 module HalApi::Controller::Actions
+  extend ActiveSupport::Concern
+
+  included do
+    class_eval do
+      class_attribute :valid_params
+    end
+  end
+
   def index
     respond_with index_collection, index_options
   end
@@ -92,8 +100,6 @@ module HalApi::Controller::Actions
 
 
   module ClassMethods
-    attr_accessor :valid_params
-
     def allow_params(action, *params)
       self.valid_params ||= {}
       valid_params[action.to_sym] = Array(params).flatten

--- a/lib/hal_api/controller/actions.rb
+++ b/lib/hal_api/controller/actions.rb
@@ -80,14 +80,14 @@ module HalApi::Controller::Actions
   end
 
   def hal_authorize(resource)
-    if respond_to?(:authorize)
-      authorize(resource)
-    else
-      define_singleton_method(:authorize, Proc.new(resource) do
+    if !respond_to?(:authorize)
+      define_singleton_method(:authorize) do |_resource|
         true
-      end)
+      end
       singleton_class.send(:alias_method, :hal_authorize, :authorize)
     end
+
+    authorize(resource)
   end
 
 

--- a/lib/hal_api/controller/cache.rb
+++ b/lib/hal_api/controller/cache.rb
@@ -1,4 +1,6 @@
 module HalApi::Controller::Cache
+  extend ActiveSupport::Concern
+
   private
 
   def index_cache_path

--- a/lib/hal_api/controller/exceptions.rb
+++ b/lib/hal_api/controller/exceptions.rb
@@ -4,6 +4,8 @@ require 'action_dispatch/middleware/exception_wrapper'
 # Since we are taking over exception handling, make sure we log exceptions
 # https://github.com/rails/rails/blob/4-2-stable/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
 module HalApi::Controller::Exceptions
+  extend ActiveSupport::Concern
+
   def respond_with_error(exception)
     wrapper = ::ActionDispatch::ExceptionWrapper.new(env, exception)
     log_error(env, wrapper)

--- a/lib/hal_api/controller/resources.rb
+++ b/lib/hal_api/controller/resources.rb
@@ -1,4 +1,5 @@
 module HalApi::Controller::Resources
+  extend ActiveSupport::Concern
   private
 
   # action specific resources

--- a/lib/hal_api/representer/uri_methods.rb
+++ b/lib/hal_api/representer/uri_methods.rb
@@ -5,9 +5,13 @@ require 'active_support/concern'
 module HalApi::Representer::UriMethods
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    attr_accessor :profile_host, :alternate_host
+  included do
+    class_eval do
+      class_attribute :profile_host, :alternate_host
+    end
+  end
 
+  module ClassMethods
     def self_link
       link(:self) do
         {

--- a/test/hal_api/controller/actions_test.rb
+++ b/test/hal_api/controller/actions_test.rb
@@ -119,9 +119,9 @@ describe HalApi::Controller::Actions do
     end
 
     it 'authorizes the resource' do
-      controller.stub(:authorize, true) do
-        assert_send([controller, :authorize, {}])
-      end
+      controller.wont_be :respond_to?, :authorize
+      assert_send([controller, :hal_authorize, {}])
+      controller.must_be :respond_to?, :authorize
     end
 
     # it 'can add paging to resources query' do

--- a/test/hal_api/controller/actions_test.rb
+++ b/test/hal_api/controller/actions_test.rb
@@ -151,6 +151,10 @@ describe HalApi::Controller::Actions do
 
       FoosController.valid_params.must_equal(index: [:page, :per, :zoom])
       FoosController.valid_params_list(:index).must_equal([:page, :per, :zoom])
+
+      class ChildFoosController < FoosController; end
+      ChildFoosController.valid_params.must_equal(index: [:page, :per, :zoom])
+      ChildFoosController.valid_params_list(:index).must_equal([:page, :per, :zoom])
     end
 
     it 'sets default cache options' do

--- a/test/hal_api/controller_test.rb
+++ b/test/hal_api/controller_test.rb
@@ -53,10 +53,6 @@ describe HalApi::Controller do
       self._respond_with = args
     end
 
-    def authorize(resource)
-      true
-    end
-
     def self.caches_action(action, options = {})
       self._caches_action ||= {}
       self._caches_action[action] = options
@@ -103,9 +99,8 @@ describe HalApi::Controller do
     end
 
     it 'authorizes the resource' do
-      controller.stub(:authorize, true) do
-        assert_send([controller, :authorize])
-      end
+      assert_send([controller, :hal_authorize, {}])
+      assert_send([controller, :authorize, {}])
     end
   end
 


### PR DESCRIPTION
- [x] Singleton method for authorize not being created correctly, or explicitly returning `true` when not implemented
- [x] Several class attributes are being added in included modules, but not defined as inheritable `class_attribute`s
- [x] The hal api controller is a concern, but includes modules that are not, making the module larger, and preventing easy use of the `included` method for nested modules