### PR TITLE
Limit when paging queries are made on embeds

### DIFF
--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -75,8 +75,14 @@ module HalApi::Representer::Embeds
         }
         getter_per = options.delete(:per) || Kaminari.config.default_per_page
         options[:getter] ||= ->(*) do
-          per = getter_per == :all ? send(name).count : getter_per
-          HalApi::PagedCollection.new(send(name).page(1).per(per), nil, opts.merge(parent: self))
+          cnt = send(name).count
+          per = getter_per == :all ? cnt : getter_per
+          if cnt <= per
+            items = Kaminari.paginate_array(send(name)).page(1).per(per)
+          else
+            items = send(name).page(1).per(per)
+          end
+          HalApi::PagedCollection.new(items, nil, opts.merge(parent: self))
         end
         options[:decorator] = HalApi::PagedCollection.representer
       end


### PR DESCRIPTION
This is a performance improvement.
Only query using paging, and limits, when necessary to allow the query cache on includes to work.
When all the items would be returned, query for them all, and add paging on the resulting array.