### PR TITLE
fixup missing show cache key

### DIFF
--- a/lib/hal_api/controller/cache.rb
+++ b/lib/hal_api/controller/cache.rb
@@ -12,8 +12,19 @@ module HalApi::Controller::Cache
     ).cache_key
   end
 
+  def current_time
+    Datetime.now
+  end
+
   def show_cache_path
-    show_resource.updated_at.utc.to_i
+    timestamp = show_resource.updated_at || show_resource.created_at
+    timestamp = if timestamp.nil?
+                  # skip the cache
+                  current_time
+                else
+                  timestamp
+                end
+    timestamp.utc.to_i
   end
 
   module ClassMethods


### PR DESCRIPTION
Some show resources are missing an `updated_at` timestamp which blows up as we try to convert nil to a utc unix time. This PR guards against nil `updated_at` using the `created_at` if that's available and falling back on a cache-busting current time.

The case where `updated_at` and `created_at` are both nil is ambiguous to me. I chose to fall back on the current time, but it may make sense to use a static cache key if we assume that those resources are never going to change.