### PR TITLE
Feat/prepare for augury

### DIFF
--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack-test"
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "responders", "~> 2.0"
-  spec.add_dependency "roar-rails", "~> 1.1.0"
+  spec.add_dependency "roar-rails", "~> 1.0.2"
   spec.add_dependency "multi_json"
 
   spec.add_development_dependency "bundler"

--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activemodel", ">= 3.0.0"
   spec.add_dependency "actionpack", ">= 3.0.0"
-  spec.add_dependency "rack-test", "~> 0.6.2"
+  spec.add_dependency "rack-test"
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "responders", "~> 2.0"
   spec.add_dependency "roar-rails", "~> 1.0.1"

--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack-test"
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "responders", "~> 2.0"
-  spec.add_dependency "roar-rails", "~> 1.0.1"
+  spec.add_dependency "roar-rails", "~> 1.1.0"
   spec.add_dependency "multi_json"
 
   spec.add_development_dependency "bundler"

--- a/lib/hal_api.rb
+++ b/lib/hal_api.rb
@@ -3,4 +3,8 @@ module HalApi
   require 'hal_api/errors'
   require 'hal_api/controller'
   require 'hal_api/represented_model'
+
+  def self.rails_major_version
+    ::Rails.version.split('.')[0].to_i
+  end
 end

--- a/lib/hal_api/controller.rb
+++ b/lib/hal_api/controller.rb
@@ -27,6 +27,21 @@ module HalApi::Controller
   private
 
   def set_accepts
-    request.format = :json if request.format == Mime::HTML
+    mime_comparator = case HalApi::rails_major_version
+                      when 5
+                        Mime[:html]
+                      else
+                        Mime::HTML
+                      end
+    request.format = :json if request.format == mime_comparator
+  end
+
+  def env
+    case HalApi.rails_major_version
+    when 5
+      request.env
+    else
+      super
+    end
   end
 end

--- a/lib/hal_api/controller/exceptions.rb
+++ b/lib/hal_api/controller/exceptions.rb
@@ -7,7 +7,13 @@ module HalApi::Controller::Exceptions
   extend ActiveSupport::Concern
 
   def respond_with_error(exception)
-    wrapper = ::ActionDispatch::ExceptionWrapper.new(env, exception)
+    wrapper = case HalApi.rails_major_version
+              when 5
+                ::ActionDispatch::ExceptionWrapper.new(ActiveSupport::BacktraceCleaner.new, exception)
+              else
+                ::ActionDispatch::ExceptionWrapper.new(env, exception)
+              end
+
     log_error(env, wrapper)
 
     error = exception

--- a/lib/hal_api/rails/version.rb
+++ b/lib/hal_api/rails/version.rb
@@ -1,5 +1,5 @@
 module HalApi
   module Rails
-    VERSION = "0.3.4"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
This PR branches some logic to account for api differences between rails 4 and 5--ushering the way for augury.prx, a rails 5 app.

Per: PRX/augury.prx.org#56