### PR TITLE
Feat/fixup rails 5 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Add this line to your application's Gemfile:
 gem 'hal_api-rails'
 ```
 
+Then add a gem for paging through ActiveRecord result sets:
+```ruby
+gem 'kaminari'
+```
+
+
 And then execute:
 
     $ bundle

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![Build Status](https://travis-ci.org/PRX/hal_api-rails.svg?branch=master)](https://travis-ci.org/PRX/hal_api-rails)
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/hal_api/rails`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Welcome to hal_api-rails. This is a binding between the responders /
+roar / roar-rails gems and the the PRX HAL api.
 
 ## Installation
 

--- a/lib/hal_api/controller/actions.rb
+++ b/lib/hal_api/controller/actions.rb
@@ -72,7 +72,8 @@ module HalApi::Controller::Actions
   def valid_params_for_action(action)
     (params.permit(*self.class.valid_params_list(action)) || {}).tap do |p|
       p[:zoom] = zoom_param if zoom_param
-    end
+    end.
+    to_h
   end
 
   def zoom_param


### PR DESCRIPTION
Fixes up the interface between the responders gem and hal_api-rails.  The gist is that in rails 4 `params.permit(...).is_a?(Hash)` was true, whereas in rails 5 it returns false.

Since the responders gem depends on `extract_options`:
https://github.com/plataformatec/responders/blob/master/lib/action_controller/respond_with.rb#L210

`extract_options` assumes it is dealing with arguments derived from a method signature (array of items with hash at the end). It tests if the last item in the array `is_a?(Hash)` and pops that off as the option arg.