### PR TITLE
set up a new default api responder

### DIFF
--- a/lib/hal_api.rb
+++ b/lib/hal_api.rb
@@ -3,6 +3,7 @@ module HalApi
   require 'hal_api/errors'
   require 'hal_api/controller'
   require 'hal_api/represented_model'
+  require 'hal_api/responders/api_responder'
 
   def self.rails_major_version
     ::Rails.version.split('.')[0].to_i

--- a/lib/hal_api/controller.rb
+++ b/lib/hal_api/controller.rb
@@ -9,6 +9,7 @@ module HalApi::Controller
   require 'hal_api/controller/cache'
   require 'hal_api/controller/resources'
   require 'hal_api/controller/exceptions'
+  require 'hal_api/responders/api_responder'
 
   include HalApi::Controller::Actions
   include HalApi::Controller::Cache
@@ -22,6 +23,10 @@ module HalApi::Controller
     respond_to :hal, :json
 
     hal_rescue_standard_errors
+
+    def self.responder
+      HalApi::Responders::ApiResponder
+    end
   end
 
   private

--- a/lib/hal_api/responders/api_responder.rb
+++ b/lib/hal_api/responders/api_responder.rb
@@ -1,0 +1,19 @@
+require 'roar/rails/responder'
+
+module HalApi::Responders
+  class ApiResponder < Roar::Rails::Responder
+    def api_behavior
+      raise MissingRenderer.new(format) unless has_renderer?
+
+      if post?
+        display(resource, status: :created)
+      elsif put?
+        display(resource, status: :ok)
+      elsif delete?
+        display(resource, status: :no_content)
+      else
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to https://github.com/PRX/augury.prx.org/issues/78
This sets up a new default api responder for hal api apps.  These changes are pulled upstream from CMS.