### PR TITLE
Feat/update responders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.2.2
+  - 2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.3.8
+  - 2.4.9

--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack-test"
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "responders", "~> 3.0"
-  spec.add_dependency "roar-rails", "~> 1.0.2"
+  spec.add_dependency "roar-rails", "~> 1.1.0"
   spec.add_dependency "multi_json"
 
   spec.add_development_dependency "bundler"

--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "actionpack", ">= 3.0.0"
   spec.add_dependency "rack-test"
   spec.add_dependency "activesupport", ">= 3.0.0"
-  spec.add_dependency "responders", "~> 2.0"
+  spec.add_dependency "responders", "~> 3.0"
   spec.add_dependency "roar-rails", "~> 1.0.2"
   spec.add_dependency "multi_json"
 

--- a/hal_api-rails.gemspec
+++ b/hal_api-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rails", "~> 4.2.1"
+  spec.add_development_dependency "rails", "~> 5.2.4"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "kaminari"

--- a/lib/hal_api/controller/exceptions.rb
+++ b/lib/hal_api/controller/exceptions.rb
@@ -25,12 +25,11 @@ module HalApi::Controller::Exceptions
 
     notice_error(exception) if error.status >= 500
 
-    respond_with(
-      error,
-      status: error.status,
-      location: nil, # for POST requests
-      represent_with: HalApi::Errors::Representer
-    )
+    json = {status: error.status, message: error.message}
+    if Rails.configuration.try(:consider_all_requests_local)
+      json[:backtrace] = error.backtrace
+    end
+    render status: error.status, json: json
   end
 
   def log_error(env, wrapper)

--- a/lib/hal_api/controller/exceptions.rb
+++ b/lib/hal_api/controller/exceptions.rb
@@ -11,10 +11,10 @@ module HalApi::Controller::Exceptions
               when 5
                 ::ActionDispatch::ExceptionWrapper.new(ActiveSupport::BacktraceCleaner.new, exception)
               else
-                ::ActionDispatch::ExceptionWrapper.new(env, exception)
+                ::ActionDispatch::ExceptionWrapper.new(request.env, exception)
               end
 
-    log_error(env, wrapper)
+    log_error(request.env, wrapper)
 
     error = exception
     if !error.is_a?(HalApi::Errors::ApiError)

--- a/lib/hal_api/errors.rb
+++ b/lib/hal_api/errors.rb
@@ -48,12 +48,4 @@ module HalApi::Errors
       super(msg, 400, hint)
     end
   end
-
-  module Representer
-    include Roar::JSON::HAL
-
-    property :status
-    property :message
-    property :backtrace, if: -> (*) { Rails.configuration.try(:consider_all_requests_local) }
-  end
 end

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -37,8 +37,6 @@ module HalApi::Representer::Embeds
 
     # embed if zoomed
     def suppress_embed?(input, options)
-      return false if input.nil?
-
       user_options = options[:options]
 
       binding = options[:binding]

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -7,7 +7,7 @@ module HalApi::Representer::Embeds
   extend ActiveSupport::Concern
 
   included do
-    # Representable::Binding.send(:include, HalApiRailsRenderPipeline) if !Representable::Binding.include?(HalApiRailsRenderPipeline)
+    Representable::Binding.send(:include, HalApiRailsRenderPipeline) if !Representable::Binding.include?(HalApiRailsRenderPipeline)
   end
 
   def normalize_options!(options)
@@ -37,6 +37,8 @@ module HalApi::Representer::Embeds
 
     # embed if zoomed
     def suppress_embed?(input, options)
+      return false if input.nil?
+
       user_options = options[:options]
 
       binding = options[:binding]

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -7,7 +7,7 @@ module HalApi::Representer::Embeds
   extend ActiveSupport::Concern
 
   included do
-    Representable::Binding.send(:include, HalApiRailsRenderPipeline) if !Representable::Binding.include?(HalApiRailsRenderPipeline)
+    # Representable::Binding.send(:include, HalApiRailsRenderPipeline) if !Representable::Binding.include?(HalApiRailsRenderPipeline)
   end
 
   def normalize_options!(options)
@@ -32,7 +32,7 @@ module HalApi::Representer::Embeds
           return Representable::Pipeline::Stop
         end
       end
-      [f] + funcs 
+      [f] + funcs
     end
 
     # embed if zoomed

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -28,27 +28,27 @@ module HalApi::Representer::Embeds
     def render_functions
       funcs = super
       f = ->(input, options) do
-        # TODO FIXME
-        return
-
         if suppress_embed?(input, options)
           return Representable::Pipeline::Stop
         end
       end
-      funcs + [f]
+      [f] + funcs 
     end
 
     # embed if zoomed
     def suppress_embed?(input, options)
-      name = options[:binding].evaluate_option(:as, input, options)
-      false
-      #embedded = options[:embedded]
+      user_options = options[:options]
 
-      ## not embedded, return false - nothing to suppress
-      #return false if !embedded
+      binding = options[:binding]
+
+      name = binding.evaluate_option(:as, input, options)
+
+      embedded = binding[:embedded]
+
+      return false if !embedded
 
       ## check if it should be zoomed, suppress if not
-      #!embed_zoomed?(name, binding[:zoom], options[:zoom])
+      !embed_zoomed?(name, binding[:zoom], user_options[:zoom])
     end
 
     def embed_zoomed?(name, zoom_def = nil, zoom_param = nil)

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -1,12 +1,13 @@
 require 'active_support/concern'
 require 'hal_api/paged_collection'
 
+
 # expects underlying model to have filename, class, and id attributes
 module HalApi::Representer::Embeds
   extend ActiveSupport::Concern
 
   included do
-    Representable::Mapper.send(:include, Resources) if !Representable::Mapper.include?(Resources)
+    #Representable::Mapper.send(:include, Resources) if !Representable::Mapper.include?(Resources)
   end
 
   def normalize_options!(options)

--- a/lib/hal_api/representer/link_serialize.rb
+++ b/lib/hal_api/representer/link_serialize.rb
@@ -15,8 +15,9 @@ module HalApi::Representer::LinkSerialize
       if options.is_a?(Hash) && (options.delete(:writeable) || options[:reader])
         name = options[:rel].to_s.split(':').last.split('/').last
         pname = "set_#{name}_uri"
-        reader = options.delete(:reader) || ->(doc, _args) do
+        reader = options.delete(:reader) || ->(represented:, doc:, **) do
           try("#{name}_id=", id_from_url(doc[pname])) if doc[pname]
+          Representable::Pipeline::Stop
         end
 
         property(pname, readable: false, reader: reader)

--- a/test/hal_api/concerns/caches_test.rb
+++ b/test/hal_api/concerns/caches_test.rb
@@ -11,24 +11,24 @@ describe HalApi::Representer::Caches do
   it 'creates a cache key for a model' do
     expect = "api/test_object/r/test/true/zoom/foo/bar/page/1"
     key = representer.cache_key(t_object, { 'zoom' => ['foo', 'bar'], 'to_' => :json, 'page' => 1, '_keys' => ['zoom', 'page'] })
-    key.must_equal expect
+    _(key).must_equal expect
   end
 
   it 'gets a cache name from the class' do
-    representer.cache_key_class_name.must_equal 'api/test_object'
+    _(representer.cache_key_class_name).must_equal 'api/test_object'
   end
 
   it 'handles json strings for caching' do
     test_string = {"key" => "value"}.to_json
-    test_string.to_json.must_equal "\"{\\\"key\\\":\\\"value\\\"}\""
+    _(test_string.to_json).must_equal "\"{\\\"key\\\":\\\"value\\\"}\""
     sj = HalApi::Representer::Caches::SerializedJson.new(test_string)
-    sj.to_json.must_equal test_string
+    _(sj.to_json).must_equal test_string
   end
 
   it "adds a hint as to final format for cache optimizations" do
     options = {}
     helper.to_json(options) rescue nil
-    options[:to_].must_equal :json
+    _(options[:to_]).must_equal :json
   end
 
   # This isn't working, comment out this optimization

--- a/test/hal_api/concerns/curies_test.rb
+++ b/test/hal_api/concerns/curies_test.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'test_helper'
+require 'test_models'
 
 describe HalApi::Representer::Curies do
   it 'sets a default curie' do
@@ -11,7 +12,7 @@ describe HalApi::Representer::Curies do
       use_curie(:test)
     end
 
-    Test1Representer.default_curie.must_equal :test
+    _(Test1Representer.default_curie).must_equal :test
   end
 
   it 'defines curie links' do
@@ -32,7 +33,7 @@ describe HalApi::Representer::Curies do
     repr_attrs = repr.instance_variable_get(:@representable_attrs)
     links_obj = repr_attrs["links"]
 
-    links_obj.link_configs.size.must_equal 1
-    links_obj.link_configs.first.first[:rel].must_equal :curies
+    _(links_obj.link_configs.size).must_equal 1
+    _(links_obj.link_configs.first.first[:rel]).must_equal :curies
   end
 end

--- a/test/hal_api/concerns/curies_test.rb
+++ b/test/hal_api/concerns/curies_test.rb
@@ -24,7 +24,15 @@ describe HalApi::Representer::Curies do
       end
     end
 
-    Test2Representer.link_configs.size.must_equal 1
-    Test2Representer.link_configs.first.first[:rel].must_equal :curies
+    repr = Test2Representer.new(Object.new)
+
+    # initialize internal state
+    repr.as_json
+
+    repr_attrs = repr.instance_variable_get(:@representable_attrs)
+    links_obj = repr_attrs["links"]
+
+    links_obj.link_configs.size.must_equal 1
+    links_obj.link_configs.first.first[:rel].must_equal :curies
   end
 end

--- a/test/hal_api/concerns/embeds_test.rb
+++ b/test/hal_api/concerns/embeds_test.rb
@@ -13,12 +13,14 @@ describe HalApi::Representer::Embeds do
   let(:helper) { class TestUriMethods; include Embeds; end.new }
   let(:t_object) { TestObject.new("test", true) }
   let(:mapper) { TestEmbedsRenderPipeline.new.tap { |m| m.represented = t_object } }
+  let(:prop_name) { 'prop_name' }
   let(:repr_binding) do
+    p = prop_name
     Struct.
       new(:as, :embedded, :zoom).
       new(TestOption.new('t:test'), true, nil).
       tap do |b|
-        b.define_singleton_method(:evaluate_option) { |*| 'prop_name' }
+        b.define_singleton_method(:evaluate_option) { |*| p }
       end
   end
 
@@ -44,6 +46,7 @@ describe HalApi::Representer::Embeds do
 
   describe "zoom: true" do
     let (:true_binding) { repr_binding.tap{|b| b.zoom = true } }
+    let (:prop_name) { 't:test'}
 
     it "is not suppressed by default" do
       mapper.suppress_embed?(true_binding, {options: {}, binding: repr_binding}).must_equal false

--- a/test/hal_api/concerns/embeds_test.rb
+++ b/test/hal_api/concerns/embeds_test.rb
@@ -73,10 +73,10 @@ describe HalApi::Representer::Embeds do
       embed :test_object, class: TestObject, zoom: :always
     end
 
-    embed_definition = Embeds1TestRepresenter.representable_attrs[:definitions]['test_object']
+    embed_definition = Embeds1TestRepresenter.representable_attrs['test_object']
     embed_definition.wont_be_nil
     embed_definition[:embedded].must_equal true
-    embed_definition[:class].evaluate(nil).must_equal TestObject
+    embed_definition[:class].call.must_equal TestObject
     embed_definition[:zoom].must_equal :always
   end
 
@@ -86,10 +86,10 @@ describe HalApi::Representer::Embeds do
       embeds :test_objects, class: TestObject, zoom: :always
     end
 
-    embed_definition = Embeds2TestRepresenter.representable_attrs[:definitions]['test_objects']
+    embed_definition = Embeds2TestRepresenter.representable_attrs['test_objects']
     embed_definition.wont_be_nil
     embed_definition[:embedded].must_equal true
-    embed_definition[:class].evaluate(nil).must_equal TestObject
+    embed_definition[:class].call.must_equal TestObject
     embed_definition[:zoom].must_equal :always
   end
 end

--- a/test/hal_api/concerns/embeds_test.rb
+++ b/test/hal_api/concerns/embeds_test.rb
@@ -4,7 +4,7 @@ require 'test_models'
 
 class TestEmbedsMapper
   attr_accessor :represented
-  include HalApi::Representer::Embeds::Resources
+  include HalApi::Representer::Embeds::HalApiRailsRenderPipeline
 end
 
 EmbedsTest = Struct.new(:title)

--- a/test/hal_api/concerns/embeds_test.rb
+++ b/test/hal_api/concerns/embeds_test.rb
@@ -28,7 +28,7 @@ describe HalApi::Representer::Embeds do
     let (:non_embed_binding) { repr_binding.tap{|b| b.embedded = false } }
 
     it "is never suppressed" do
-      mapper.suppress_embed?(non_embed_binding, {options: {}, binding: repr_binding}).must_equal false
+      _(mapper.suppress_embed?(non_embed_binding, {options: {}, binding: repr_binding})).must_equal false
     end
   end
 
@@ -36,11 +36,11 @@ describe HalApi::Representer::Embeds do
     let (:default_binding) { repr_binding.tap{|b| b.zoom = nil } }
 
     it "is not suppressed by default" do
-      mapper.suppress_embed?(default_binding, {options: {}, binding: repr_binding}).must_equal false
+      _(mapper.suppress_embed?(default_binding, {options: {}, binding: repr_binding})).must_equal false
     end
 
     it "is suppressed when specifically unrequested" do
-      mapper.suppress_embed?(default_binding,{options: {zoom: ['t:none']}, binding: repr_binding} ).must_equal true
+      _(mapper.suppress_embed?(default_binding,{options: {zoom: ['t:none']}, binding: repr_binding} )).must_equal true
     end
   end
 
@@ -49,15 +49,15 @@ describe HalApi::Representer::Embeds do
     let (:prop_name) { 't:test'}
 
     it "is not suppressed by default" do
-      mapper.suppress_embed?(true_binding, {options: {}, binding: repr_binding}).must_equal false
+      _(mapper.suppress_embed?(true_binding, {options: {}, binding: repr_binding})).must_equal false
     end
 
     it "is suppressed when specifically unrequested" do
-      mapper.suppress_embed?(true_binding, {options: {zoom: ['t:none']}, binding: repr_binding}).must_equal true
+      _(mapper.suppress_embed?(true_binding, {options: {zoom: ['t:none']}, binding: repr_binding})).must_equal true
     end
 
     it "is unsuppressed when requested" do
-      mapper.suppress_embed?(true_binding, {options: {zoom: ['t:test']}, binding: repr_binding}).must_equal false
+      _(mapper.suppress_embed?(true_binding, {options: {zoom: ['t:test']}, binding: repr_binding})).must_equal false
     end
   end
 
@@ -65,7 +65,7 @@ describe HalApi::Representer::Embeds do
     let (:always_binding) { repr_binding.tap{|b| b.zoom = :always } }
 
     it "is not suppressed when specifically unrequested" do
-      mapper.suppress_embed?(always_binding, {options: {zoom: ['t:test']}, binding: repr_binding}).must_equal false
+      _(mapper.suppress_embed?(always_binding, {options: {zoom: ['t:test']}, binding: repr_binding})).must_equal false
     end
   end
 
@@ -73,7 +73,7 @@ describe HalApi::Representer::Embeds do
     let (:false_binding) { repr_binding.tap{|b| b.zoom = false } }
 
     it "is suppressed by default" do
-      mapper.suppress_embed?(false_binding, {options: {}, binding: repr_binding}).must_equal true
+      _(mapper.suppress_embed?(false_binding, {options: {}, binding: repr_binding})).must_equal true
     end
   end
 
@@ -84,10 +84,10 @@ describe HalApi::Representer::Embeds do
     end
 
     embed_definition = Embeds1TestRepresenter.representable_attrs['test_object']
-    embed_definition.wont_be_nil
-    embed_definition[:embedded].must_equal true
-    embed_definition[:class].call.must_equal TestObject
-    embed_definition[:zoom].must_equal :always
+    _(embed_definition).wont_be_nil
+    _(embed_definition[:embedded]).must_equal true
+    _(embed_definition[:class].call).must_equal TestObject
+    _(embed_definition[:zoom]).must_equal :always
   end
 
   it "defines an embed to set a representable property" do
@@ -97,9 +97,9 @@ describe HalApi::Representer::Embeds do
     end
 
     embed_definition = Embeds2TestRepresenter.representable_attrs['test_objects']
-    embed_definition.wont_be_nil
-    embed_definition[:embedded].must_equal true
-    embed_definition[:class].call.must_equal TestObject
-    embed_definition[:zoom].must_equal :always
+    _(embed_definition).wont_be_nil
+    _(embed_definition[:embedded]).must_equal true
+    _(embed_definition[:class].call).must_equal TestObject
+    _(embed_definition[:zoom]).must_equal :always
   end
 end

--- a/test/hal_api/concerns/link_serialize_test.rb
+++ b/test/hal_api/concerns/link_serialize_test.rb
@@ -16,8 +16,8 @@ describe HalApi::Representer::LinkSerialize do
       end
     end
 
-    TestRepresenter.representable_attrs['set_foo_uri'].wont_be_nil
-    TestRepresenter.representable_attrs['set_foo_uri'][:readable].must_equal false
-    TestRepresenter.representable_attrs['set_foo_uri'][:reader].wont_be_nil
+    _(TestRepresenter.representable_attrs['set_foo_uri']).wont_be_nil
+    _(TestRepresenter.representable_attrs['set_foo_uri'][:readable]).must_equal false
+    _(TestRepresenter.representable_attrs['set_foo_uri'][:reader]).wont_be_nil
   end
 end

--- a/test/hal_api/concerns/link_serialize_test.rb
+++ b/test/hal_api/concerns/link_serialize_test.rb
@@ -16,8 +16,8 @@ describe HalApi::Representer::LinkSerialize do
       end
     end
 
-    TestRepresenter.representable_attrs[:definitions]['set_foo_uri'].wont_be_nil
-    TestRepresenter.representable_attrs[:definitions]['set_foo_uri'][:readable].must_equal false
-    TestRepresenter.representable_attrs[:definitions]['set_foo_uri'][:reader].wont_be_nil
+    TestRepresenter.representable_attrs['set_foo_uri'].wont_be_nil
+    TestRepresenter.representable_attrs['set_foo_uri'][:readable].must_equal false
+    TestRepresenter.representable_attrs['set_foo_uri'][:reader].wont_be_nil
   end
 end

--- a/test/hal_api/concerns/uri_methods_test.rb
+++ b/test/hal_api/concerns/uri_methods_test.rb
@@ -40,7 +40,7 @@ describe HalApi::Representer::UriMethods do
   let(:representer) { Api::TestObjectRepresenter.new(t_object) }
 
   it 'gets the path for url to represented' do
-    representer.model_path(t_object).must_equal 'test_objects/1'
+    _(representer.model_path(t_object)).must_equal 'test_objects/1'
   end
 
   it 'helps an object become the represented base class' do
@@ -55,45 +55,45 @@ describe HalApi::Representer::UriMethods do
         'became'
       end
     end
-    representer.becomes_represented_class(FooChild.new).must_equal 'became'
+    _(representer.becomes_represented_class(FooChild.new)).must_equal 'became'
   end
 
   it 'creates a url to an alt web site' do
-    representer.alternate_url('rainbows', 1).must_equal 'https://www.test.dev/rainbows/1'
+    _(representer.alternate_url('rainbows', 1)).must_equal 'https://www.test.dev/rainbows/1'
   end
 
   it 'creates a uri for a model' do
     uri = "http://meta.test.dev/model/test-object"
-    helper.model_uri('test_object').must_equal uri
-    helper.model_uri(:test_object).must_equal uri
-    helper.model_uri(TestObject).must_equal uri
-    helper.model_uri(t_object).must_equal uri
+    _(helper.model_uri('test_object')).must_equal uri
+    _(helper.model_uri(:test_object)).must_equal uri
+    _(helper.model_uri(TestObject)).must_equal uri
+    _(helper.model_uri(t_object)).must_equal uri
 
     b = "http://meta.test.dev/model"
-    helper.model_uri(Widget.new).must_equal "#{b}/widget"
-    helper.model_uri(SpecialWidget.new).must_equal "#{b}/widget/special"
-    helper.model_uri(VerySpecialThing.new).must_equal "#{b}/widget/very-special-thing"
+    _(helper.model_uri(Widget.new)).must_equal "#{b}/widget"
+    _(helper.model_uri(SpecialWidget.new)).must_equal "#{b}/widget/special"
+    _(helper.model_uri(VerySpecialThing.new)).must_equal "#{b}/widget/very-special-thing"
   end
 
   it 'sets host uri attributes for parent' do
     alt_uri = "http://alt.meta.test.dev/model/test-object"
-    alt_helper.model_uri('test_object').must_equal alt_uri
-    child_helper.model_uri('test_object').must_equal alt_uri
+    _(alt_helper.model_uri('test_object')).must_equal alt_uri
+    _(child_helper.model_uri('test_object')).must_equal alt_uri
 
     alt_b = "http://alt.meta.test.dev/model"
-    alt_helper.model_uri(Widget.new).must_equal "#{alt_b}/widget"
-    child_helper.model_uri(Widget.new).must_equal "#{alt_b}/widget"
+    _(alt_helper.model_uri(Widget.new)).must_equal "#{alt_b}/widget"
+    _(child_helper.model_uri(Widget.new)).must_equal "#{alt_b}/widget"
   end
 
   it 'returns the meta host' do
-    representer.profile_url.must_equal 'http://meta.test.dev/model/'
+    _(representer.profile_url).must_equal 'http://meta.test.dev/model/'
   end
 
   it 'returns the web host' do
-    representer.alternate_url.must_equal 'https://www.test.dev/'
+    _(representer.alternate_url).must_equal 'https://www.test.dev/'
   end
 
   it 'uses path template for method missing' do
-    representer.api_tests_path_template(title: '{title}').must_equal "/api/tests/{title}"
+    _(representer.api_tests_path_template(title: '{title}')).must_equal "/api/tests/{title}"
   end
 end

--- a/test/hal_api/controller/actions_test.rb
+++ b/test/hal_api/controller/actions_test.rb
@@ -76,9 +76,9 @@ describe HalApi::Controller::Actions do
 
   describe 'errors' do
     it 'handles invalid content type errors' do
-      lambda do
+      _(lambda do
         controller.create
-      end.must_raise Roar::Rails::UnsupportedMediaType
+      end).must_raise Roar::Rails::UnsupportedMediaType
     end
 
     it 'handles not found errors' do
@@ -92,79 +92,79 @@ describe HalApi::Controller::Actions do
   describe 'instance methods' do
 
     it 'retrieves resource' do
-      controller.send(:resource).must_be_instance_of Foo
+      _(controller.send(:resource)).must_be_instance_of Foo
     end
 
     it 'retrieves new resource when id not found' do
       controller.params = ActionController::Parameters.new(action: 'create')
       controller.request = OpenStruct.new('put?' => false, 'post?' => true)
-      controller.send(:resource).must_be_instance_of Foo
-      controller.send(:resource).id.must_be_nil
+      _(controller.send(:resource)).must_be_instance_of Foo
+      _(controller.send(:resource).id).must_be_nil
     end
 
     it 'determines resource id for caching' do
-      controller.send(:show_cache_path).must_equal 60
+      _(controller.send(:show_cache_path)).must_equal 60
     end
 
     it 'determines the resources id for caching' do
       cache_key = 'c/foos/1a8ca71da20c9dc2dfc2e02485821d9b'
-      controller.send(:index_cache_path).must_equal cache_key
+      _(controller.send(:index_cache_path)).must_equal cache_key
     end
 
     it 'responds to show request' do
       controller.show
-      controller._respond_with.wont_be_nil
-      controller._respond_with.first.must_be_instance_of Foo
-      controller._respond_with.last[:_keys].must_equal []
+      _(controller._respond_with).wont_be_nil
+      _(controller._respond_with.first).must_be_instance_of Foo
+      _(controller._respond_with.last[:_keys]).must_equal []
     end
 
     it 'authorizes the resource' do
-      controller.wont_be :respond_to?, :authorize
+      _(controller).wont_be :respond_to?, :authorize
       assert controller.send(:hal_authorize, {})
-      controller.must_be :respond_to?, :authorize
+      _(controller).must_be :respond_to?, :authorize
     end
 
     # it 'can add paging to resources query' do
     #   arel = FoosController.new.send(:paged, Account.where('id is not null'))
-    #   arel.to_sql.must_match /LIMIT 10 OFFSET 0/
+    #   _(arel.to_sql).must_match /LIMIT 10 OFFSET 0/
     # end
   end
 
   describe 'class methods' do
 
     it 'determines class for resource' do
-      FoosController.resource_class.must_equal Foo
+      _(FoosController.resource_class).must_equal Foo
     end
 
     it 'can specify filter params' do
       FoosController.filter_resources_by(:bar_id)
-      FoosController.resources_params.must_equal [:bar_id]
+      _(FoosController.resources_params).must_equal [:bar_id]
     end
 
     it 'can specify representer' do
       FoosController.represent_with(FooRepresenter)
-      FoosController.resource_representer.must_equal FooRepresenter
+      _(FoosController.resource_representer).must_equal FooRepresenter
     end
 
     it 'specify allowed params for an action' do
       FoosController.allow_params :index, [:page, :per, :zoom]
 
-      FoosController.valid_params.must_equal(index: [:page, :per, :zoom])
-      FoosController.valid_params_list(:index).must_equal([:page, :per, :zoom])
+      _(FoosController.valid_params).must_equal(index: [:page, :per, :zoom])
+      _(FoosController.valid_params_list(:index)).must_equal([:page, :per, :zoom])
 
       class ChildFoosController < FoosController; end
-      ChildFoosController.valid_params.must_equal(index: [:page, :per, :zoom])
-      ChildFoosController.valid_params_list(:index).must_equal([:page, :per, :zoom])
+      _(ChildFoosController.valid_params).must_equal(index: [:page, :per, :zoom])
+      _(ChildFoosController.valid_params_list(:index)).must_equal([:page, :per, :zoom])
     end
 
     it 'sets default cache options' do
       default_opts = { compress: true, expires_in: 1.hour, race_condition_ttl: 30 }
-      FoosController.cache_options.must_equal(default_opts)
+      _(FoosController.cache_options).must_equal(default_opts)
     end
 
     it 'caches api actions' do
       FoosController.cache_api_action(:index, bar: true)
-      FoosController._caches_action[:index][:bar].must_equal true
+      _(FoosController._caches_action[:index][:bar]).must_equal true
     end
   end
 end

--- a/test/hal_api/controller/exceptions_test.rb
+++ b/test/hal_api/controller/exceptions_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
 describe HalApi::Controller::Exceptions < ActionController::TestCase do
-  include ActiveSupport::Testing::SetupAndTeardown
-  include ActionController::TestCase::Behavior
+
+  #include ActiveSupport::Testing::SetupAndTeardown
+  #include ActionController::TestCase::Behavior
 
   class TestRoutes
     def extra_keys(*any) []; end

--- a/test/hal_api/controller/exceptions_test.rb
+++ b/test/hal_api/controller/exceptions_test.rb
@@ -35,28 +35,28 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
 
   it 'rescues from standard errors' do
     get :throwerror, {format: :hal}
-    response.status.must_equal 500
+    _(response.status).must_equal 500
     json = JSON.parse(response.body)
-    json['status'].must_equal 500
-    json['message'].must_equal 'what now'
-    json.key?('backtrace').must_equal false
+    _(json['status']).must_equal 500
+    _(json['message']).must_equal 'what now'
+    _(json.key?('backtrace')).must_equal false
   end
 
   it 'optionally shows backtraces' do
     Rails.configuration.consider_all_requests_local = true
     get :throwerror, {format: :hal}
     json = JSON.parse(response.body)
-    json.key?('backtrace').must_equal true
-    json['backtrace'].must_be_instance_of Array
+    _(json.key?('backtrace')).must_equal true
+    _(json['backtrace']).must_be_instance_of Array
   end
 
   it 'does not try to set a location header for post errors' do
     post :throwerror, {format: :hal}
-    response.status.must_equal 500
+    _(response.status).must_equal 500
     json = JSON.parse(response.body)
-    json['status'].must_equal 500
-    json['message'].must_equal 'what now'
-    response.headers['Location'].must_be_nil
+    _(json['status']).must_equal 500
+    _(json['message']).must_equal 'what now'
+    _(response.headers['Location']).must_be_nil
   end
 
   describe 'with new relic defined' do
@@ -79,7 +79,7 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
       end
       NewRelic::Agent.stub :notice_error, notice do
         get :throwerror, {format: :hal}
-        response.status.must_equal 500
+        _(response.status).must_equal 500
         notice.verify
       end
     end
@@ -88,7 +88,7 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
       notice = -> { raise StandardError.new('should not have called this') }
       NewRelic::Agent.stub :notice_error, notice do
         get :thrownotfound, {format: :hal}
-        response.status.must_equal 404
+        _(response.status).must_equal 404
       end
     end
 

--- a/test/hal_api/controller/exceptions_test.rb
+++ b/test/hal_api/controller/exceptions_test.rb
@@ -1,14 +1,8 @@
 require 'test_helper'
 
-describe HalApi::Controller::Exceptions < ActionController::TestCase do
+describe HalApi::Controller::Exceptions do
 
-  #include ActiveSupport::Testing::SetupAndTeardown
-  #include ActionController::TestCase::Behavior
-
-  class TestRoutes
-    def extra_keys(*any) []; end
-    def path_for(*any) ''; end
-  end
+  include ActionDispatch::IntegrationTest::Behavior
 
   class ExceptionsTestController < ActionController::Base
     include Roar::Rails::ControllerAdditions
@@ -27,14 +21,18 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
 
   before do
     Rails.configuration.consider_all_requests_local = false
-    @controller = ExceptionsTestController.new
-    @request = ActionController::TestRequest.new
-    @response = ActionController::TestResponse.new
-    @routes = TestRoutes.new
+    Rails.application.routes.draw do
+      get '/throwerror', to: 'exceptions_test#throwerror'
+      post '/throwerror', to: 'exceptions_test#throwerror'
+      get '/thrownotfound', to: 'exceptions_test#thrownotfound'
+    end
+  end
+  after do
+    Rails.application.reload_routes!
   end
 
   it 'rescues from standard errors' do
-    get :throwerror, {format: :hal}
+    get '/throwerror.hal'
     _(response.status).must_equal 500
     json = JSON.parse(response.body)
     _(json['status']).must_equal 500
@@ -44,21 +42,21 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
 
   it 'optionally shows backtraces' do
     Rails.configuration.consider_all_requests_local = true
-    get :throwerror, {format: :hal}
+    get '/throwerror.hal'
     json = JSON.parse(response.body)
     _(json.key?('backtrace')).must_equal true
     _(json['backtrace']).must_be_instance_of Array
   end
 
   it 'does not try to set a location header for post errors' do
-    post :throwerror, {format: :hal}
+    post '/throwerror.hal'
     _(response.status).must_equal 500
     json = JSON.parse(response.body)
     _(json['status']).must_equal 500
     _(json['message']).must_equal 'what now'
     _(response.headers['Location']).must_be_nil
   end
-
+  #
   describe 'with new relic defined' do
 
     before do
@@ -78,7 +76,7 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
         err.message == 'what now'
       end
       NewRelic::Agent.stub :notice_error, notice do
-        get :throwerror, {format: :hal}
+        get '/throwerror.hal'
         _(response.status).must_equal 500
         notice.verify
       end
@@ -87,7 +85,7 @@ describe HalApi::Controller::Exceptions < ActionController::TestCase do
     it 'does not notice 400 errors' do
       notice = -> { raise StandardError.new('should not have called this') }
       NewRelic::Agent.stub :notice_error, notice do
-        get :thrownotfound, {format: :hal}
+        get '/thrownotfound.hal'
         _(response.status).must_equal 404
       end
     end

--- a/test/hal_api/controller/filtering_test.rb
+++ b/test/hal_api/controller/filtering_test.rb
@@ -33,90 +33,90 @@ describe HalApi::Controller::Filtering do
 
   it 'parses query params' do
     controller.filter_string = 'one,two=2,three=something,four='
-    controller.filters.one.must_equal true
-    controller.filters.two.must_equal 2
-    controller.filters.three.must_equal 'something'
-    controller.filters.four.must_equal ''
+    _(controller.filters.one).must_equal true
+    _(controller.filters.two).must_equal 2
+    _(controller.filters.three).must_equal 'something'
+    _(controller.filters.four).must_equal ''
   end
 
   it 'restricts to known params' do
     controller.filter_string = 'one,foo,two,bar'
-    controller.filters.one.must_equal true
-    controller.filters.two.must_equal true
+    _(controller.filters.one).must_equal true
+    _(controller.filters.two).must_equal true
     err = assert_raises { controller.filters.foo }
-    err.must_be_instance_of(HalApi::Errors::UnknownFilterError)
-    err.hint.must_match /valid filters are: one two/i
+    _(err).must_be_instance_of(HalApi::Errors::UnknownFilterError)
+    _(err.hint).must_match /valid filters are: one two/i
     err = assert_raises { controller.filters.whatever }
-    err.must_be_instance_of(HalApi::Errors::UnknownFilterError)
-    err.hint.must_match /valid filters are: one two/i
+    _(err).must_be_instance_of(HalApi::Errors::UnknownFilterError)
+    _(err.hint).must_match /valid filters are: one two/i
   end
 
   it 'provides boolean testers' do
     controller.filter_string = 'one,two=1,three=false,four=,five=0'
-    controller.filters.one?.must_equal true
-    controller.filters.two?.must_equal true
-    controller.filters.three?.must_equal false
-    controller.filters.four?.must_equal true
-    controller.filters.five?.must_equal true
-    controller.filters.six?.must_equal false
-    controller.filters.seven?.must_equal false
+    _(controller.filters.one?).must_equal true
+    _(controller.filters.two?).must_equal true
+    _(controller.filters.three?).must_equal false
+    _(controller.filters.four?).must_equal true
+    _(controller.filters.five?).must_equal true
+    _(controller.filters.six?).must_equal false
+    _(controller.filters.seven?).must_equal false
     assert_raises { controller.filters.whatever? }
   end
 
   it 'defaults to nil/false for unset filters' do
     controller.filter_string = nil
-    controller.filters.one.must_be_nil
-    controller.filters.one?.must_equal false
+    _(controller.filters.one).must_be_nil
+    _(controller.filters.one?).must_equal false
   end
 
   it 'parses dates' do
     controller.filter_string = 'six=20190203'
-    controller.filters.six?.must_equal true
-    controller.filters.six.must_equal Date.parse('2019-02-03')
+    _(controller.filters.six?).must_equal true
+    _(controller.filters.six).must_equal Date.parse('2019-02-03')
   end
 
   it 'raises parse errors for dates' do
     controller.filter_string = 'six=bad-string'
     err = assert_raises { puts controller.filters.six }
-    err.must_be_instance_of(HalApi::Errors::BadFilterValueError)
+    _(err).must_be_instance_of(HalApi::Errors::BadFilterValueError)
   end
 
   it 'parses datetimes' do
     controller.filter_string = 'seven=2019-02-03T01:02:03 -0700'
-    controller.filters.seven?.must_equal true
-    controller.filters.seven.must_equal Time.parse('2019-02-03T08:02:03Z')
+    _(controller.filters.seven?).must_equal true
+    _(controller.filters.seven).must_equal Time.parse('2019-02-03T08:02:03Z')
   end
 
   it 'defaults datetimes to utc' do
     controller.filter_string = 'seven=20190203'
-    controller.filters.seven?.must_equal true
-    controller.filters.seven.must_equal Time.parse('2019-02-03T00:00:00Z')
+    _(controller.filters.seven?).must_equal true
+    _(controller.filters.seven).must_equal Time.parse('2019-02-03T00:00:00Z')
   end
 
   it 'raises parse errors for times' do
     controller.filter_string = 'seven=bad-string'
     err = assert_raises { puts controller.filters.seven }
-    err.must_be_instance_of(HalApi::Errors::BadFilterValueError)
+    _(err).must_be_instance_of(HalApi::Errors::BadFilterValueError)
   end
 
   it 'sets facets on the collection' do
-    controller.index_collection.facets[:one].must_equal [{'count' => 2}]
-    controller.index_collection.facets[:three].count.must_equal 2
-    controller.index_collection.facets[:three][0].must_equal({'id' => 'a', 'count' => 4})
-    controller.index_collection.facets[:three][1].must_equal({'id' => 'b', 'count' => 5})
+    _(controller.index_collection.facets[:one]).must_equal [{'count' => 2}]
+    _(controller.index_collection.facets[:three].count).must_equal 2
+    _(controller.index_collection.facets[:three][0]).must_equal({'id' => 'a', 'count' => 4})
+    _(controller.index_collection.facets[:three][1]).must_equal({'id' => 'b', 'count' => 5})
   end
 
   it 'removes empty facets' do
-    controller.index_collection.facets.keys.must_include 'one'
-    controller.index_collection.facets.keys.must_include 'three'
-    controller.index_collection.facets[:three].map { |f| f['id'] }.wont_include 'c'
-    controller.index_collection.facets.keys.wont_include 'four'
-    controller.index_collection.facets.keys.wont_include 'five'
-    controller.index_collection.facets.keys.wont_include 'six'
+    _(controller.index_collection.facets.keys).must_include 'one'
+    _(controller.index_collection.facets.keys).must_include 'three'
+    _(controller.index_collection.facets[:three].map { |f| f['id'] }).wont_include 'c'
+    _(controller.index_collection.facets.keys).wont_include 'four'
+    _(controller.index_collection.facets.keys).wont_include 'five'
+    _(controller.index_collection.facets.keys).wont_include 'six'
   end
 
   it 'does not set facets if there are none' do
     controller.no_facets = true
-    controller.index_collection.facets.must_be_nil
+    _(controller.index_collection.facets).must_be_nil
   end
 end

--- a/test/hal_api/controller/sorting_test.rb
+++ b/test/hal_api/controller/sorting_test.rb
@@ -22,73 +22,73 @@ describe HalApi::Controller::Sorting do
   end
 
   it 'sets a default array of sorts' do
-    controller.class.default_sort.must_equal [{ one: :desc }]
+    _(controller.class.default_sort).must_equal [{ one: :desc }]
   end
 
   it 'parses query params' do
-    controller.sorts.count.must_equal 4
+    _(controller.sorts.count).must_equal 4
   end
 
   it 'defaults sorts to desc' do
     one = controller.sorts[0]
-    one.keys.count.must_equal 1
-    one.keys[0].must_equal 'one'
-    one['one'].must_equal 'desc'
+    _(one.keys.count).must_equal 1
+    _(one.keys[0]).must_equal 'one'
+    _(one['one']).must_equal 'desc'
   end
 
   it 'can specify asc order' do
     two = controller.sorts[1]
-    two.keys.count.must_equal 1
-    two.keys[0].must_equal 'two'
-    two['two'].must_equal 'asc'
+    _(two.keys.count).must_equal 1
+    _(two.keys[0]).must_equal 'two'
+    _(two['two']).must_equal 'asc'
   end
 
   it 'can specify desc order' do
     three = controller.sorts[2]
-    three.keys.count.must_equal 1
-    three.keys[0].must_equal 'three'
-    three['three'].must_equal 'desc'
+    _(three.keys.count).must_equal 1
+    _(three.keys[0]).must_equal 'three'
+    _(three['three']).must_equal 'desc'
   end
 
   it 'defaults to desc if it ends with a semi-colon' do
     four = controller.sorts[3]
-    four.keys.count.must_equal 1
-    four.keys[0].must_equal 'four'
-    four['four'].must_equal 'desc'
+    _(four.keys.count).must_equal 1
+    _(four.keys[0]).must_equal 'four'
+    _(four['four']).must_equal 'desc'
   end
 
   it 'throws an error on sorts that are not asc or desc' do
     controller.sort_string = 'one:blah'
     err = assert_raises { controller.sorts }
-    err.must_be_instance_of(HalApi::Errors::BadSortError)
-    err.message.must_match /invalid sort direction/i
-    err.hint.must_match /valid directions are: asc desc/i
+    _(err).must_be_instance_of(HalApi::Errors::BadSortError)
+    _(err.message).must_match /invalid sort direction/i
+    _(err.hint).must_match /valid directions are: asc desc/i
   end
 
   it 'throws an error on sorts that are not declared' do
     controller.sort_string = 'foobar'
     err = assert_raises { controller.sorts }
-    err.must_be_instance_of(HalApi::Errors::BadSortError)
-    err.message.must_match /invalid sort/i
-    err.hint.must_match /valid sorts are: one two/i
+    _(err).must_be_instance_of(HalApi::Errors::BadSortError)
+    _(err.message).must_match /invalid sort/i
+    _(err.hint).must_match /valid sorts are: one two/i
   end
 
   it 'allows camel case sorts' do
     controller.sort_string = 'camel_case'
-    controller.sorts[0].keys.must_equal ['camel_case']
+    _(controller.sorts[0].keys).must_equal ['camel_case']
 
     controller.sort_string = 'CamelCase'
-    controller.sorts[0].keys.must_equal ['camel_case']
+    _(controller.sorts[0].keys).must_equal ['camel_case']
 
     controller.sort_string = 'camelCase'
-    controller.sorts[0].keys.must_equal ['camel_case']
+    _(controller.sorts[0].keys).must_equal ['camel_case']
   end
 
   it 'sorted adds orders to resources arel' do
     sorts = [{ 'one' => 'desc' }, { 'two' => 'asc' }, { 'three' => 'desc' }, { 'four' => 'desc' }]
     table = Arel::Table.new(:api_test_sorting)
     result = controller.sorted(table)
-    result.orders.must_equal sorts
+    _(result.orders).must_equal sorts
   end
 
   it 'sorted adds default orders to resources arel' do
@@ -96,6 +96,6 @@ describe HalApi::Controller::Sorting do
     sorts = [{ one: :desc }]
     table = Arel::Table.new(:api_test_sorting)
     result = controller.sorted(table)
-    result.orders.must_equal sorts
+    _(result.orders).must_equal sorts
   end
 end

--- a/test/hal_api/controller_test.rb
+++ b/test/hal_api/controller_test.rb
@@ -63,39 +63,39 @@ describe HalApi::Controller do
 
   describe 'errors' do
     it 'handles invalid content type errors' do
-      lambda do
+      _(lambda do
         controller.create
-      end.must_raise Roar::Rails::UnsupportedMediaType
+      end).must_raise Roar::Rails::UnsupportedMediaType
     end
   end
 
   describe 'instance methods' do
 
     it 'retrieves resource' do
-      controller.send(:resource).must_be_instance_of Foo
+      _(controller.send(:resource)).must_be_instance_of Foo
     end
 
     it 'retrieves new resource when id not found' do
       controller.params = ActionController::Parameters.new(action: 'create')
       controller.request = OpenStruct.new('put?' => false, 'post?' => true)
-      controller.send(:resource).must_be_instance_of Foo
-      controller.send(:resource).id.must_be_nil
+      _(controller.send(:resource)).must_be_instance_of Foo
+      _(controller.send(:resource).id).must_be_nil
     end
 
     it 'determines resource id for caching' do
-      controller.send(:show_cache_path).must_equal 60
+      _(controller.send(:show_cache_path)).must_equal 60
     end
 
     it 'determines the resources id for caching' do
       cache_key = 'c/foos/1a8ca71da20c9dc2dfc2e02485821d9b'
-      controller.send(:index_cache_path).must_equal cache_key
+      _(controller.send(:index_cache_path)).must_equal cache_key
     end
 
     it 'responds to show request' do
       controller.show
-      controller._respond_with.wont_be_nil
-      controller._respond_with.first.must_be_instance_of Foo
-      controller._respond_with.last[:_keys].must_equal []
+      _(controller._respond_with).wont_be_nil
+      _(controller._respond_with.first).must_be_instance_of Foo
+      _(controller._respond_with.last[:_keys]).must_equal []
     end
 
     it 'authorizes the resource' do
@@ -107,14 +107,14 @@ describe HalApi::Controller do
       let(:some_foo) { Foo.find }
 
       it "returns a path based on an updated_at timestamp" do
-        controller.send(:show_cache_path).must_equal 60
+        _(controller.send(:show_cache_path)).must_equal 60
       end
 
       it "returns a path based on created_at if updated_at is nil" do
         some_foo.updated_at = nil
         some_foo.created_at = DateTime.parse('1970-01-01 00:00:30')
         controller.stub(:resource, some_foo) do
-          controller.send(:show_cache_path).must_equal 30
+          _(controller.send(:show_cache_path)).must_equal 30
         end
       end
       it "uses the current time if update_at and created_at are nil" do
@@ -122,7 +122,7 @@ describe HalApi::Controller do
         some_foo.created_at = nil
         controller.stub(:resource, some_foo) do
           controller.stub(:current_time, DateTime.parse('1970-01-01 00:05:33')) do
-            controller.send(:show_cache_path).must_equal 333
+            _(controller.send(:show_cache_path)).must_equal 333
           end
         end
       end
@@ -132,34 +132,34 @@ describe HalApi::Controller do
   describe 'class methods' do
 
     it 'determines class for resource' do
-      FoosController.resource_class.must_equal Foo
+      _(FoosController.resource_class).must_equal Foo
     end
 
     it 'can specify filter params' do
       FoosController.filter_resources_by(:bar_id)
-      FoosController.resources_params.must_equal [:bar_id]
+      _(FoosController.resources_params).must_equal [:bar_id]
     end
 
     it 'can specify representer' do
       FoosController.represent_with(FooRepresenter)
-      FoosController.resource_representer.must_equal FooRepresenter
+      _(FoosController.resource_representer).must_equal FooRepresenter
     end
 
     it 'specify allowed params for an action' do
       FoosController.allow_params :index, [:page, :per, :zoom]
 
-      FoosController.valid_params.must_equal(index: [:page, :per, :zoom])
-      FoosController.valid_params_list(:index).must_equal([:page, :per, :zoom])
+      _(FoosController.valid_params).must_equal(index: [:page, :per, :zoom])
+      _(FoosController.valid_params_list(:index)).must_equal([:page, :per, :zoom])
     end
 
     it 'sets default cache options' do
       default_opts = { compress: true, expires_in: 1.hour, race_condition_ttl: 30 }
-      FoosController.cache_options.must_equal(default_opts)
+      _(FoosController.cache_options).must_equal(default_opts)
     end
 
     it 'caches api actions' do
       FoosController.cache_api_action(:index, bar: true)
-      FoosController._caches_action[:index][:bar].must_equal true
+      _(FoosController._caches_action[:index][:bar]).must_equal true
     end
   end
 end

--- a/test/hal_api/errors_test.rb
+++ b/test/hal_api/errors_test.rb
@@ -6,15 +6,15 @@ describe HalApi::Errors do
     let(:subject) { HalApi::Errors::ApiError.new('foo', nil, 'bar') }
 
     it 'has status 500' do
-      subject.status.must_equal 500
+      _(subject.status).must_equal 500
     end
 
     it 'has a helpful message' do
-      subject.message.must_equal 'foo'
+      _(subject.message).must_equal 'foo'
     end
 
     it 'has a helpful hint' do
-      subject.hint.must_equal 'bar'
+      _(subject.hint).must_equal 'bar'
     end
   end
 
@@ -22,12 +22,12 @@ describe HalApi::Errors do
     let(:subject) { HalApi::Errors::NotFound.new }
 
     it 'has status 404' do
-      subject.status.must_equal 404
+      _(subject.status).must_equal 404
     end
 
     it 'has a helpful message' do
-      subject.message.must_be :kind_of?, String
-      subject.message.must_equal "Resource Not Found"
+      _(subject.message).must_be :kind_of?, String
+      _(subject.message).must_equal "Resource Not Found"
     end
   end
 
@@ -35,11 +35,11 @@ describe HalApi::Errors do
     let(:subject) { HalApi::Errors::UnsupportedMediaType.new('foo') }
 
     it 'has status 415' do
-      subject.status.must_equal 415
+      _(subject.status).must_equal 415
     end
 
     it 'has a helpful message' do
-      subject.message.must_be :kind_of?, String
+      _(subject.message).must_be :kind_of?, String
     end
   end
 end

--- a/test/hal_api/paged_collection_representer_test.rb
+++ b/test/hal_api/paged_collection_representer_test.rb
@@ -22,30 +22,30 @@ describe HalApi::PagedCollectionRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'creates a paged collection representer' do
-    representer.wont_be_nil
+    _(representer).wont_be_nil
   end
 
   it 'has a represented_url' do
     representer.represented.options[:url] = "api_stories_path"
-    representer.represented_url.must_equal "api_stories_path"
+    _(representer.represented_url).must_equal "api_stories_path"
   end
 
   it 'has a vary link' do
     representer.represented.options[:url] = "api_stories_path"
-    json['_links']['vary'].wont_be_nil
-    json['_links']['vary']['href'].must_equal 'api_stories_path{?page,per,zoom,filters,sorts}'
-    json['_links']['vary']['templated'].must_equal true
+    _(json['_links']['vary']).wont_be_nil
+    _(json['_links']['vary']['href']).must_equal 'api_stories_path{?page,per,zoom,filters,sorts}'
+    _(json['_links']['vary']['templated']).must_equal true
   end
 
   it 'uses a lambda for a url method' do
     representer.represented.options[:url] = ->(options){ options.keys.sort.join('/') }
-    representer.href_url_helper({foo: 1, bar: 2, camp: 3}).must_equal "bar/camp/foo"
+    _(representer.href_url_helper({foo: 1, bar: 2, camp: 3})).must_equal "bar/camp/foo"
   end
 
   it 'uses a lambda for a url method, references represented parent' do
     representer.represented.options[:parent] = "this is a test"
     representer.represented.options[:url] = ->(options){ represented.parent }
-    representer.href_url_helper({foo: 1, bar: 2, camp: 3}).must_equal "this is a test"
+    _(representer.href_url_helper({foo: 1, bar: 2, camp: 3})).must_equal "this is a test"
   end
 
   describe 'requires routes' do
@@ -54,14 +54,14 @@ describe HalApi::PagedCollectionRepresenter do
     after { Rails.application.reload_routes! }
 
     it 'paged collection contains tests _links' do
-      json['_embedded']['items'].wont_be_nil
-      json['_embedded']['items'].size.must_equal 10
+      _(json['_embedded']['items']).wont_be_nil
+      _(json['_embedded']['items'].size).must_equal 10
     end
 
     it 'gets a route url helper method' do
       representer.represented.options[:url] = "api_test_objects_path"
-      representer.represented_url.must_equal "api_test_objects_path"
-      representer.href_url_helper({page: 1}).must_equal "/api/test_objects?page=1"
+      _(representer.represented_url).must_equal "api_test_objects_path"
+      _(representer.href_url_helper({page: 1})).must_equal "/api/test_objects?page=1"
     end
 
     it 'gets a route url helper method with parent' do
@@ -69,7 +69,7 @@ describe HalApi::PagedCollectionRepresenter do
       representer.represented.options[:item_class] = TestObject
 
       nested_page = '/api/test_parents/1/test_objects?page=1'
-      representer.href_url_helper(page: 1).must_equal nested_page
+      _(representer.href_url_helper(page: 1)).must_equal nested_page
     end
   end
 end

--- a/test/hal_api/paged_collection_test.rb
+++ b/test/hal_api/paged_collection_test.rb
@@ -11,56 +11,56 @@ describe HalApi::PagedCollection do
   let(:paged_collection) { HalApi::PagedCollection.new(paged_items, OpenStruct.new(params: {})) }
 
   it 'creates a paged collection' do
-    paged_collection.wont_be_nil
-    paged_collection.items.wont_be_nil
-    paged_collection.request.wont_be_nil
+    _(paged_collection).wont_be_nil
+    _(paged_collection.items).wont_be_nil
+    _(paged_collection.request).wont_be_nil
   end
 
   it 'has delegated methods' do
-    paged_collection.request.params.must_equal Hash.new
-    paged_collection.params.must_equal Hash.new
+    _(paged_collection.request.params).must_equal Hash.new
+    _(paged_collection.params).must_equal Hash.new
 
-    paged_collection.items.count.must_equal 10
-    paged_collection.count.must_equal 10
-    paged_collection.items.total_count.must_equal 26
-    paged_collection.total.must_equal 26
+    _(paged_collection.items.count).must_equal 10
+    _(paged_collection.count).must_equal 10
+    _(paged_collection.items.total_count).must_equal 26
+    _(paged_collection.total).must_equal 26
   end
 
   it 'implements to_model' do
     paged_collection = HalApi::PagedCollection.new([])
-    paged_collection.to_model.must_equal paged_collection
+    _(paged_collection.to_model).must_equal paged_collection
   end
 
   it 'is never persisted' do
     paged_collection = HalApi::PagedCollection.new([])
-    paged_collection.wont_be :persisted?
+    _(paged_collection).wont_be :persisted?
   end
 
   it 'has a stubbed request by default' do
     paged_collection = HalApi::PagedCollection.new([])
-    paged_collection.params.must_equal Hash.new
+    _(paged_collection.params).must_equal Hash.new
   end
 
   it 'will be a root resource be default' do
-    paged_collection.is_root_resource.must_equal true
+    _(paged_collection.is_root_resource).must_equal true
   end
 
   it 'will be a root resource based on options' do
     paged_collection.options[:is_root_resource] = false
-    paged_collection.is_root_resource.must_equal false
+    _(paged_collection.is_root_resource).must_equal false
   end
 
   it 'has an item_class' do
-    paged_collection.item_class.must_equal(TestObject)
+    _(paged_collection.item_class).must_equal(TestObject)
   end
 
   it 'has an item_decorator' do
-    paged_collection.item_decorator.must_equal(Api::TestObjectRepresenter)
+    _(paged_collection.item_decorator).must_equal(Api::TestObjectRepresenter)
   end
 
   it 'has an url' do
     paged_collection.options[:url] = "test"
-    paged_collection.url.must_equal "test"
+    _(paged_collection.url).must_equal "test"
   end
 
   it 'has a parent' do
@@ -76,8 +76,8 @@ describe HalApi::PagedCollection do
     end
 
     a = TestBar.new
-    a.wont_be_instance_of TestFoo
+    _(a).wont_be_instance_of TestFoo
     paged_collection.options[:parent] = a
-    paged_collection.parent.must_be_instance_of TestFoo
+    _(paged_collection.parent).must_be_instance_of TestFoo
   end
 end

--- a/test/hal_api/rails_test.rb
+++ b/test/hal_api/rails_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 describe HalApi::Rails do
   it 'has a version number' do
-    ::HalApi::Rails::VERSION.wont_be_nil
+    _(::HalApi::Rails::VERSION).wont_be_nil
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,6 @@ module Dummy
     config.encoding = 'utf-8'
     config.eager_load = false
     config.active_support.test_order = :random
-    config.secret_token = '1234'
     config.secret_key_base = '5678'
   end
 end


### PR DESCRIPTION
This PR updates the responders gem to 3.0, and as a consequence updates the representable gem.

There are some hooks here in hal_api-rails that leverage dependency injection in the rendering of docs /attributes, and since representable underwent a big change in 2.2->2.3 this PR rewrites some of that code.