### PR TITLE
Feat/non hal representers

### DIFF
--- a/lib/hal_api/controller/exceptions.rb
+++ b/lib/hal_api/controller/exceptions.rb
@@ -25,11 +25,12 @@ module HalApi::Controller::Exceptions
 
     notice_error(exception) if error.status >= 500
 
-    json = {status: error.status, message: error.message}
-    if Rails.configuration.try(:consider_all_requests_local)
-      json[:backtrace] = error.backtrace
-    end
-    render status: error.status, json: json
+    respond_with(
+      error,
+      status: error.status,
+      location: nil, # for POST requests
+      represent_with: HalApi::Errors::Representer
+    )
   end
 
   def log_error(env, wrapper)

--- a/lib/hal_api/errors.rb
+++ b/lib/hal_api/errors.rb
@@ -48,4 +48,12 @@ module HalApi::Errors
       super(msg, 400, hint)
     end
   end
+
+  module Representer
+    include Roar::JSON::HAL
+
+    property :status
+    property :message
+    property :backtrace, if: -> (*) { Rails.configuration.try(:consider_all_requests_local) }
+  end
 end

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -37,11 +37,12 @@ module HalApi::Representer::Embeds
 
     # embed if zoomed
     def suppress_embed?(input, options)
-      return false if input.nil?
-
       user_options = options[:options]
 
       binding = options[:binding]
+
+      # guard against non-hal representers
+      return false unless binding[:as].present?
 
       name = binding.evaluate_option(:as, input, options)
 

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -37,6 +37,8 @@ module HalApi::Representer::Embeds
 
     # embed if zoomed
     def suppress_embed?(input, options)
+      return false if input.nil?
+
       user_options = options[:options]
 
       binding = options[:binding]

--- a/test/hal_api/concerns/embeds_test.rb
+++ b/test/hal_api/concerns/embeds_test.rb
@@ -102,4 +102,17 @@ describe HalApi::Representer::Embeds do
     _(embed_definition[:class].call).must_equal TestObject
     _(embed_definition[:zoom]).must_equal :always
   end
+
+  it 'does not interfere with non-halapi representers' do
+    class ThingRepresenter < Representable::Decorator
+      include Representable::JSON
+      include HalApi::Representer::Embeds
+      property :foo
+    end
+
+    class Thing < OpenStruct; end
+
+    thing = Thing.new(foo: 'bar', any: 'thing')
+    _(ThingRepresenter.new(thing).to_json).must_equal '{"foo":"bar"}'
+  end
 end


### PR DESCRIPTION
Sets up a guard in the embed machinery against probing non-hal representer properties.

Reverts the earlier change in the exceptions code so that this change is covered in tests.