### PR TITLE
Fix nested resource zooms

### DIFF
--- a/lib/hal_api/controller/actions.rb
+++ b/lib/hal_api/controller/actions.rb
@@ -71,7 +71,9 @@ module HalApi::Controller::Actions
 
   def valid_params_for_action(action)
     (params.permit(*self.class.valid_params_list(action)) || {}).tap do |p|
-      p[:zoom] = zoom_param if zoom_param
+      if zoom_param
+        p[:user_options] = (p[:user_options] || {}).merge(zoom: zoom_param)
+      end
     end.
     to_h
   end

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -28,8 +28,6 @@ module HalApi::Representer::Embeds
 
     # embed if zoomed
     def suppress_embed?(input, options)
-      user_options = options[:options]
-
       binding = options[:binding]
 
       # guard against non-hal representers

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -10,15 +10,6 @@ module HalApi::Representer::Embeds
     Representable::Binding.send(:include, HalApiRailsRenderPipeline) if !Representable::Binding.include?(HalApiRailsRenderPipeline)
   end
 
-  def normalize_options!(options)
-    propagated_options, private_options = super(options)
-
-    # we want this to propogate, and be available for `skip_property?`, so don't delete
-    private_options[:zoom] = options[:zoom] if options.key?(:zoom)
-
-    [propagated_options, private_options]
-  end
-
   module HalApiRailsRenderPipeline
 
     def skip_property?(binding, private_options)
@@ -51,7 +42,8 @@ module HalApi::Representer::Embeds
       return false if !embedded
 
       ## check if it should be zoomed, suppress if not
-      !embed_zoomed?(name, binding[:zoom], user_options[:zoom])
+      user_zooms = options[:options].try(:[], :user_options).try(:[], :zoom)
+      !embed_zoomed?(name, binding[:zoom], user_zooms)
     end
 
     def embed_zoomed?(name, zoom_def = nil, zoom_param = nil)

--- a/test/hal_api/concerns/embeds_test.rb
+++ b/test/hal_api/concerns/embeds_test.rb
@@ -40,7 +40,8 @@ describe HalApi::Representer::Embeds do
     end
 
     it "is suppressed when specifically unrequested" do
-      _(mapper.suppress_embed?(default_binding,{options: {zoom: ['t:none']}, binding: repr_binding} )).must_equal true
+      options = {user_options: {zoom: ['t:none']}}
+      _(mapper.suppress_embed?(default_binding, {options: options, binding: repr_binding} )).must_equal true
     end
   end
 
@@ -53,11 +54,13 @@ describe HalApi::Representer::Embeds do
     end
 
     it "is suppressed when specifically unrequested" do
-      _(mapper.suppress_embed?(true_binding, {options: {zoom: ['t:none']}, binding: repr_binding})).must_equal true
+      options = {user_options: {zoom: ['t:none']}}
+      _(mapper.suppress_embed?(true_binding, {options: options, binding: repr_binding})).must_equal true
     end
 
     it "is unsuppressed when requested" do
-      _(mapper.suppress_embed?(true_binding, {options: {zoom: ['t:test']}, binding: repr_binding})).must_equal false
+      options = {user_options: {zoom: ['t:test']}}
+      _(mapper.suppress_embed?(true_binding, {options: options, binding: repr_binding})).must_equal false
     end
   end
 
@@ -65,7 +68,8 @@ describe HalApi::Representer::Embeds do
     let (:always_binding) { repr_binding.tap{|b| b.zoom = :always } }
 
     it "is not suppressed when specifically unrequested" do
-      _(mapper.suppress_embed?(always_binding, {options: {zoom: ['t:test']}, binding: repr_binding})).must_equal false
+      options = {user_options: {zoom: ['t:test']}}
+      _(mapper.suppress_embed?(always_binding, {options: options, binding: repr_binding})).must_equal false
     end
   end
 


### PR DESCRIPTION
The `?zoom` parameter was working correctly for "show" resources.  But not for "index" resources, where the representers are nested under `prx:items`.