### PR TITLE
Fix for newer kaminari

### DIFF
--- a/lib/hal_api/rails/version.rb
+++ b/lib/hal_api/rails/version.rb
@@ -1,5 +1,5 @@
 module HalApi
   module Rails
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end

--- a/lib/hal_api/representer/embeds.rb
+++ b/lib/hal_api/representer/embeds.rb
@@ -85,7 +85,9 @@ module HalApi::Representer::Embeds
         options[:getter] ||= ->(*) do
           cnt = send(name).count
           per = getter_per == :all ? cnt : getter_per
-          if cnt <= per
+          if cnt == 0
+            items = send(name).page(1).per(Kaminari.config.default_per_page)
+          elsif cnt <= per
             items = Kaminari.paginate_array(send(name)).page(1).per(per)
           else
             items = send(name).page(1).per(per)


### PR DESCRIPTION
Newer kaminari versions throw a `Kaminari::ZeroPerPageOperation` if you ever call `per(0)`.

I'll have to also manually release a `0.3.5` patch for Feeder/CMS.