### PR TITLE
Less fatal logging

### DIFF
--- a/lib/hal_api/rails/version.rb
+++ b/lib/hal_api/rails/version.rb
@@ -1,5 +1,5 @@
 module HalApi
   module Rails
-    VERSION = '1.1.5'
+    VERSION = '1.1.6'
   end
 end


### PR DESCRIPTION
Stop logging error statuses < 500 as fatal.  In fact, stop logging them at all!