### PR TITLE
Ruby 3: Guard against caller not supplying kwargs properly

### DIFF
--- a/lib/hal_api/representer/link_serialize.rb
+++ b/lib/hal_api/representer/link_serialize.rb
@@ -15,7 +15,8 @@ module HalApi::Representer::LinkSerialize
       if options.is_a?(Hash) && (options.delete(:writeable) || options[:reader])
         name = options[:rel].to_s.split(':').last.split('/').last
         pname = "set_#{name}_uri"
-        reader = options.delete(:reader) || ->(represented:, doc:, **) do
+        reader = options.delete(:reader) || ->(obj) do
+          doc = obj[:doc]
           try("#{name}_id=", id_from_url(doc[pname])) if doc[pname]
           Representable::Pipeline::Stop
         end


### PR DESCRIPTION
It's possible that this fixed in the declarative-option 0.1.1 release, but that version was yanked from ruby gems due to downstream consumers finding kwarg incompatibilities.